### PR TITLE
Expose valid function

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The third parameter **level** explains the majority and purpose of the update.
 You may want to validate a version string against a format:
 ```js
 try {
-  calver.valid('yyyy.mm.minor.modifier', '2021.5-alpha.1', 'minor')
+  calver.valid('yyyy.mm.minor.modifier', '2021.5-alpha.1')
 } catch (e) {
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -185,6 +185,7 @@ function Calver() {
     inc: inc,
     pretty: pretty,
     getTagType: getTagType
+    valid: valid
   }
 }
 


### PR DESCRIPTION
- The valid function exists in docs and tests but is not actually exported. 

> TypeError: calver.valid is not a function