### PR TITLE
Support for local time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ calver.isValid('yyyy.mm.0w', '2020.6.1') === false // because 0W can't be "1", i
 calver.isValid('yyyy.mm.minor.patch', '0.0.0.1') === false // because YYYY and MM can't be "0"
 ```
 
+### Timezone
+calver's default timezone is UTC. If you want to use local timezone, set `useLocalTime`.
+```js
+calver.useLocalTime = true
+```
+
 ## Tests
 ```js
 npm run test

--- a/src/DateVersion.js
+++ b/src/DateVersion.js
@@ -3,7 +3,7 @@ export default class DateVersion {
 
   reDigits = /[^0-9]/
 
-  constructor(obj, parentSeperator, isInitialVersion) {
+  constructor(obj, parentSeperator, isInitialVersion, date) {
     this['YYYY'] = null
     this['YY'] = null
     this['0Y'] = null
@@ -18,7 +18,7 @@ export default class DateVersion {
     this.isInitialVersion = isInitialVersion
     this.parentSeperator = parentSeperator
     this.props = []
-    this.date = new Date(Date.now())
+    this.date = date
 
     this.parse(obj)
   }
@@ -37,20 +37,20 @@ export default class DateVersion {
   inc(level) {
     const prevValue = this.asString()
 
-    const yearstr = this.date.getUTCFullYear().toString()
+    const yearstr = this.date.getFullYear().toString()
     this['YYYY'] = yearstr
     this['YY'] = parseInt(yearstr.slice(2)).toString()
     this['0Y'] = this['YY'].padStart(2, '0')
 
-    const monthstr = (this.date.getUTCMonth() + 1).toString()
+    const monthstr = (this.date.getMonth() + 1).toString()
     this['MM'] = monthstr
     this['0M'] = this['MM'].padStart(2, '0')
 
-    const weekstr = this.getUTCWeek(this.date).toString()
+    const weekstr = this.date.getWeek().toString()
     this['WW'] = weekstr
     this['0W'] = this['WW'].padStart(2, '0')
 
-    const daystr = this.date.getUTCDate().toString()
+    const daystr = this.date.getDate().toString()
     this['DD'] = daystr
     this['0D'] = this['DD'].padStart(2, '0')
 
@@ -122,16 +122,5 @@ export default class DateVersion {
       if (this.props.indexOf(tag) !== -1) result.push(this[tag])
     }
     return result.join(this.parentSeperator)
-  }
-
-  getUTCWeek(date) {
-    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
-    const daynum = d.getUTCDay() || 7
-
-    d.setUTCDate(d.getUTCDate() + 4 - daynum)
-
-    const yearstart = new Date( Date.UTC(d.getUTCFullYear(), 0, 1) )
-
-    return Math.ceil((((d - yearstart) / 86400000) + 1)/7)
   }
 }

--- a/src/LocalDate.js
+++ b/src/LocalDate.js
@@ -1,0 +1,37 @@
+export default class LocalDate {
+  constructor() {
+    this.date = new Date(Date.now())
+  }
+
+  getFullYear() {
+    return this.date.getFullYear()
+  }
+
+  getMonth() {
+    return this.date.getMonth()
+  }
+
+  getWeek() {
+    return this.getWeek()
+  }
+
+  getDate() {
+    return this.date.getDate()
+  }
+
+  getWeek() {
+    const d = new Date(
+      this.date.getFullYear(),
+      this.date.getMonth(),
+      this.date.getDate()
+    )
+    const daynum = d.getDay() || 7
+
+    d.setDate(d.getDate() + 4 - daynum)
+
+    const yearstart = new Date(d.getFullYear(), 0, 1)
+
+    return Math.ceil(((d - yearstart) / 86400000 + 1) / 7)
+  }
+}
+

--- a/src/UtcDate.js
+++ b/src/UtcDate.js
@@ -1,0 +1,38 @@
+export default class UtcDate {
+  constructor() {
+    this.date = new Date(Date.now())
+  }
+
+  getFullYear() {
+    return this.date.getUTCFullYear()
+  }
+
+  getMonth() {
+    return this.date.getUTCMonth()
+  }
+
+  getWeek() {
+    return this.getUTCWeek()
+  }
+
+  getDate() {
+    return this.date.getUTCDate()
+  }
+
+  getUTCWeek() {
+    const d = new Date(
+      Date.UTC(
+        this.date.getFullYear(),
+        this.date.getMonth(),
+        this.date.getDate()
+      )
+    );
+    const daynum = d.getUTCDay() || 7
+
+    d.setUTCDate(d.getUTCDate() + 4 - daynum)
+
+    const yearstart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+
+    return Math.ceil(((d - yearstart) / 86400000 + 1) / 7)
+  }
+}

--- a/src/Version.js
+++ b/src/Version.js
@@ -3,7 +3,7 @@ import SemanticVersion from './SemanticVersion.js'
 import ModifierVersion from './ModifierVersion.js'
 
 export default class Version {
-  constructor(version, seperator) {
+  constructor(version, seperator, date) {
     this.seperator = seperator
     this.versionStringHasModifier = version.versionStringHasModifier
     this.isInitialVersion = version.isInitialVersion
@@ -11,13 +11,14 @@ export default class Version {
     this.datever = null
     this.semanticver = null
     this.modifierver = null
+    this.date = date
 
     this.parse(version)
   }
 
   parse(version) {
     if (Object.keys(version.calendar).length > 0) {
-      this.datever = new DateVersion(version.calendar, this.seperator, this.isInitialVersion)
+      this.datever = new DateVersion(version.calendar, this.seperator, this.isInitialVersion, this.date)
     }
 
     if (Object.keys(version.semantic).length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,24 @@
 import DateVersion from './DateVersion.js'
 import SemanticVersion from './SemanticVersion.js'
 import ModifierVersion from './ModifierVersion.js'
+import UtcDate from './UtcDate.js'
+import LocalDate from './LocalDate.js'
 import Version from './Version.js'
 
 class Calver {
   constructor() {
     this.seperator = '.'
     this.levels = ['CALENDAR', 'MAJOR', 'MINOR', 'PATCH', ...ModifierVersion.tags]
+    this._useLocalTime = false
   }
 
   inc(format, version, levels) {
     levels = this.validateLevels(levels)
     format = this.validateFormat(format, levels)
     const parsedVersion = this.parseVersion(version, format, levels)
+    const date = this._useLocalTime ? new LocalDate() : new UtcDate()
 
-    const obj = (new Version(parsedVersion, this.seperator)).inc(levels).asObject()
+    const obj = (new Version(parsedVersion, this.seperator, date)).inc(levels).asObject()
 
     const result = this.asString(format, obj)
 
@@ -162,6 +166,10 @@ class Calver {
     }
 
     return result
+  }
+
+  set useLocalTime(value) {
+    this._useLocalTime = value
   }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,6 +7,10 @@ Date.now = function now() {
   return 1611069856248;
 }
 
+// fixed current timezone for test environment.
+// calver respects UTC as a default timezone unless explicitly set useLocalTime as true.
+process.env.TZ = 'Asia/Tokyo'
+
 assert.strictEqual(calver.isValid('yyyy.mm.0w', '2020.6.1'), false)
 assert.strictEqual(calver.isValid('yyyy.mm.0w', '2020.6.01'), true)
 assert.strictEqual(calver.isValid('yyyy.mm.minor.patch', '2022.8.0.0'), true)
@@ -63,3 +67,9 @@ assert.strictEqual(calver.inc('YY.MM.MINOR', '21.1.0', 'calendar.minor'), '21.1.
 assert.strictEqual(calver.inc('YY.MM.MINOR', '21.1.1', 'calendar.minor'), '21.1.2')
 
 assert.strictEqual(calver.inc('yyyy.mm.minor.patch', '', 'calendar'), '2021.1.0.0')
+
+assert.strictEqual(calver.inc('yyyy.mm.dd.minor.patch', '', 'calendar'), '2021.1.19.0.0')
+
+calver.useLocalTime = true
+
+assert.strictEqual(calver.inc('yyyy.mm.dd.minor.patch', '', 'calendar'), '2021.1.20.0.0')


### PR DESCRIPTION
Ref: https://github.com/muratgozel/node-calver/issues/12

- Based on the current implementation, I implemented the `useLocalTime` API because I thought it would be less buggy and predictable. 
- Added GitHub Actions for test

Please let me know if you have any requests. @muratgozel 