### PR TITLE
Allow starting semantic components from non-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ calver's default timezone is UTC. If you want to use local timezone, set `useLoc
 calver.useLocalTime = true
 ```
 
+### Counting from 1
+For non-date parts of a version (e.g. the `minor` version in the format `YYYY.MM.MINOR`, or the modifier in `2023.7.0-rc.1`), semantic versioning is used, so that the increment begins from `0`. To start skip zero and always start from `1` (or anything else), set `startFrom`:
+
+```js
+calver.startFrom = 1
+calver.inc('yyyy.mm.minor', '', 'calendar') // 2021.1.1
+```
+
 ## Tests
 ```js
 npm run test

--- a/src/ModifierVersion.js
+++ b/src/ModifierVersion.js
@@ -4,7 +4,7 @@ export default class ModifierVersion {
 
   reDigits = /[^0-9\-]/
 
-  constructor(obj, parentSeperator, isInitialVersion) {
+  constructor(obj, parentSeperator, isInitialVersion, startFrom) {
     this.DEV = null
     this.ALPHA = null
     this.BETA = null
@@ -12,6 +12,7 @@ export default class ModifierVersion {
 
     this.isInitialVersion = isInitialVersion
     this.parentSeperator = parentSeperator
+    this.startFrom = startFrom
     this.prop = null
 
     this.parse(obj)

--- a/src/SemanticVersion.js
+++ b/src/SemanticVersion.js
@@ -3,13 +3,14 @@ export default class SemanticVersion {
 
   reDigits = /[^0-9]/
 
-  constructor(obj, parentSeperator, isInitialVersion) {
+  constructor(obj, parentSeperator, isInitialVersion, startFrom) {
     this.MAJOR = null
     this.MINOR = null
     this.PATCH = null
 
     this.isInitialVersion = isInitialVersion
     this.parentSeperator = parentSeperator
+    this.startFrom = startFrom
     this.props = []
 
     this.parse(obj)
@@ -27,7 +28,7 @@ export default class SemanticVersion {
   }
 
   reset() {
-    this.props.map(prop => this[prop] = 0)
+    this.props.map(prop => this[prop] = this.startFrom)
   }
 
   inc(level) {
@@ -37,13 +38,13 @@ export default class SemanticVersion {
 
     if (level == 'MAJOR') {
       this.MAJOR = (parseInt(this.MAJOR) + 1).toString()
-      if (this.props.indexOf('MINOR') !== -1) this.MINOR = '0'
-      if (this.props.indexOf('PATCH') !== -1) this.PATCH = '0'
+      if (this.props.indexOf('MINOR') !== -1) this.MINOR = this.startFrom.toString()
+      if (this.props.indexOf('PATCH') !== -1) this.PATCH = this.startFrom.toString()
     }
     
     if (level == 'MINOR') {
       this.MINOR = (parseInt(this.MINOR) + 1).toString()
-      if (this.props.indexOf('PATCH') !== -1) this.PATCH = '0'
+      if (this.props.indexOf('PATCH') !== -1) this.PATCH = this.startFrom.toString()
     }
 
     if (level == 'PATCH') {

--- a/src/Version.js
+++ b/src/Version.js
@@ -3,8 +3,9 @@ import SemanticVersion from './SemanticVersion.js'
 import ModifierVersion from './ModifierVersion.js'
 
 export default class Version {
-  constructor(version, seperator, date) {
+  constructor(version, seperator, date, startFrom) {
     this.seperator = seperator
+    this.startFrom = startFrom
     this.versionStringHasModifier = version.versionStringHasModifier
     this.isInitialVersion = version.isInitialVersion
     this.isCalendarLeading = version.isCalendarLeading
@@ -22,11 +23,11 @@ export default class Version {
     }
 
     if (Object.keys(version.semantic).length > 0) {
-      this.semanticver = new SemanticVersion(version.semantic, this.seperator, this.isInitialVersion)
+      this.semanticver = new SemanticVersion(version.semantic, this.seperator, this.isInitialVersion, this.startFrom)
     }
 
     if (Object.keys(version.modifier).length > 0) {
-      this.modifierver = new ModifierVersion(version.modifier, this.seperator, this.isInitialVersion)
+      this.modifierver = new ModifierVersion(version.modifier, this.seperator, this.isInitialVersion, this.startFrom)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,15 +10,16 @@ class Calver {
     this.seperator = '.'
     this.levels = ['CALENDAR', 'MAJOR', 'MINOR', 'PATCH', ...ModifierVersion.tags]
     this._useLocalTime = false
+    this.startFrom = 0
   }
 
   inc(format, version, levels) {
     levels = this.validateLevels(levels)
     format = this.validateFormat(format, levels)
-    const parsedVersion = this.parseVersion(version, format, levels)
+    const parsedVersion = this.parseVersion(version, format, levels, this.startFrom)
     const date = this._useLocalTime ? new LocalDate() : new UtcDate()
 
-    const obj = (new Version(parsedVersion, this.seperator, date)).inc(levels).asObject()
+    const obj = (new Version(parsedVersion, this.seperator, date, this.startFrom)).inc(levels).asObject()
 
     const result = this.asString(format, obj)
 
@@ -98,7 +99,7 @@ class Calver {
       }
 
       if (ModifierVersion.tags.indexOf(value.toUpperCase()) !== -1) {
-        if (value.toUpperCase() != tag) value = '-1'
+        if (value.toUpperCase() != tag) value = (this.startFrom - 1).toString()
         else value = version.slice(startIndex + value.length + 1)
       }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -78,3 +78,9 @@ assert.strictEqual(calver.inc('yyyy.mm.dd.minor.patch', '', 'calendar'), '2021.1
 
 assert.strictEqual(calver.inc('yyyy.mm.minor', '2020.12.2', 'calendar.minor.rc'), '2021.1.0-rc.0')
 assert.strictEqual(calver.inc('yyyy.mm.minor', '2020.12.2', 'calendar.rc'), '2021.1.0-rc.0')
+
+calver.startFrom = 1
+assert.strictEqual(calver.inc('yyyy.mm.minor', '2020.11.1-rc.3', 'calendar.minor'), '2021.1.1')
+assert.strictEqual(calver.inc('yyyy.mm.minor', '2021.1.1-rc.2', 'calendar.minor.dev'), '2021.1.1-dev.1')
+assert.strictEqual(calver.inc('yyyy.mm.minor', '2019.8.5-rc.2', 'calendar.minor.rc'), '2021.1.1-rc.3')
+calver.startFrom = 0


### PR DESCRIPTION
This PR adds a config input, `calver.startFrom` (default: `0`), which can be used to start the numbering of semantic components from e.g. `1` instead of `0`.

Possibly useful to some downstream packages using this which have raised it as a feature request: https://github.com/casmith/release-it-calver-plugin/issues/28